### PR TITLE
feat: leaving existing nginx configs intact

### DIFF
--- a/root/etc/cont-init.d/90-ghost-config
+++ b/root/etc/cont-init.d/90-ghost-config
@@ -17,7 +17,7 @@ cat <<"EOF"
 EOF
 
 # copy in custom configs
-cp -r /nginx/ /config/
+cp -rn /nginx/ /config/
 rm -rf /nginx
 
 # generate the password file


### PR DESCRIPTION
Any changes to nginx subdomain configs were getting clobbered on startup.